### PR TITLE
Support cpp

### DIFF
--- a/src/FastaVector.c
+++ b/src/FastaVector.c
@@ -52,7 +52,7 @@ void fastaVectorDealloc(struct FastaVector *fastaVector) {
 }
 #ifdef __cplusplus
 enum FastaVectorReturnCode
-fastaVectorReadFasta(const char * __restrict__ const fileSrc,
+fastaVectorReadFasta(const char *__restrict__ const fileSrc,
                      struct FastaVector *fastaVector) {
 #else
 enum FastaVectorReturnCode
@@ -173,7 +173,7 @@ fastaVectorReadFasta(const char *restrict const fileSrc,
 }
 
 #ifdef __cplusplus
-fastaVectorWriteFasta(const char * __restrict__ const fileSrc,
+fastaVectorWriteFasta(const char *__restrict__ const fileSrc,
                       struct FastaVector *fastaVector,
                       uint32_t fileLineLength) {
 #else

--- a/src/FastaVector.c
+++ b/src/FastaVector.c
@@ -50,10 +50,15 @@ void fastaVectorDealloc(struct FastaVector *fastaVector) {
   fastaVectorStringDealloc(&fastaVector->header);
   fastaVectorMetadataVectorDealloc(&fastaVector->metadata);
 }
-
+#ifdef __cplusplus
+enum FastaVectorReturnCode
+fastaVectorReadFasta(const char * __restrict__ const fileSrc,
+                     struct FastaVector *fastaVector) {
+#else
 enum FastaVectorReturnCode
 fastaVectorReadFasta(const char *restrict const fileSrc,
                      struct FastaVector *fastaVector) {
+#endif
 
   FILE *fastaFile = fopen(fileSrc, "r");
   if (__builtin_expect(!fastaFile, false)) {
@@ -167,10 +172,16 @@ fastaVectorReadFasta(const char *restrict const fileSrc,
   return FASTA_VECTOR_OK;
 }
 
+#ifdef __cplusplus
+fastaVectorWriteFasta(const char * __restrict__ const fileSrc,
+                      struct FastaVector *fastaVector,
+                      uint32_t fileLineLength) {
+#else
 enum FastaVectorReturnCode
 fastaVectorWriteFasta(const char *restrict const fileSrc,
                       struct FastaVector *fastaVector,
                       uint32_t fileLineLength) {
+#endif
   FILE *fastaFile = fopen(fileSrc, "w+");
   if (!fastaFile) {
     return FASTA_VECTOR_FILE_WRITE_FAIL;

--- a/src/FastaVector.h
+++ b/src/FastaVector.h
@@ -98,9 +98,15 @@ void fastaVectorDealloc(struct FastaVector *fastaVector);
  * takes any properly formed fasta file, and loads all headers and sequences.
  *
  */
+#ifdef __cplusplus
+enum FastaVectorReturnCode
+fastaVectorReadFasta(const char * __restrict__ const fileSrc,
+                     struct FastaVector *fastaVector);
+#else
 enum FastaVectorReturnCode
 fastaVectorReadFasta(const char *restrict const fileSrc,
                      struct FastaVector *fastaVector);
+#endif
 
 /**
  * @relates FastaVector
@@ -118,9 +124,15 @@ fastaVectorReadFasta(const char *restrict const fileSrc,
  * This function will overwrite the file at the given path.
  *
  */
+#ifdef __cplusplus
+enum FastaVectorReturnCode
+fastaVectorWriteFasta(const char * __restrict__ const filePath,
+                      struct FastaVector *fastaVector, uint32_t fileLineLength);
+#else
 enum FastaVectorReturnCode
 fastaVectorWriteFasta(const char *restrict const filePath,
                       struct FastaVector *fastaVector, uint32_t fileLineLength);
+#endif
 
 /**
  * @relates FastaVector

--- a/src/FastaVector.h
+++ b/src/FastaVector.h
@@ -100,7 +100,7 @@ void fastaVectorDealloc(struct FastaVector *fastaVector);
  */
 #ifdef __cplusplus
 enum FastaVectorReturnCode
-fastaVectorReadFasta(const char * __restrict__ const fileSrc,
+fastaVectorReadFasta(const char *__restrict__ const fileSrc,
                      struct FastaVector *fastaVector);
 #else
 enum FastaVectorReturnCode
@@ -126,7 +126,7 @@ fastaVectorReadFasta(const char *restrict const fileSrc,
  */
 #ifdef __cplusplus
 enum FastaVectorReturnCode
-fastaVectorWriteFasta(const char * __restrict__ const filePath,
+fastaVectorWriteFasta(const char *__restrict__ const filePath,
                       struct FastaVector *fastaVector, uint32_t fileLineLength);
 #else
 enum FastaVectorReturnCode

--- a/tests/fileReadTest/makefile
+++ b/tests/fileReadTest/makefile
@@ -1,0 +1,9 @@
+TEST_NAME = fileReadTest
+TEST_SRC	= $(TEST_NAME).c
+SRC 			= $(wildcard ../../src/*.c)
+CFLAGS 	= -std=c11 -fsanitize=address -Wall -mtune=native -g
+EXE 		= $(TEST_NAME).out
+
+.PHONY: $(TEST_NAME)
+insertTest: $(SRC)
+	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)

--- a/tests/fileWriteTest/makefile
+++ b/tests/fileWriteTest/makefile
@@ -1,0 +1,9 @@
+TEST_NAME = fileWriteTest
+TEST_SRC	= $(TEST_NAME).c
+SRC 			= $(wildcard ../../src/*.c)
+CFLAGS 	= -std=c11 -fsanitize=address -Wall -mtune=native -g
+EXE 		= $(TEST_NAME).out
+
+.PHONY: $(TEST_NAME)
+insertTest: $(SRC)
+	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)

--- a/tests/insertTest/makefile
+++ b/tests/insertTest/makefile
@@ -1,0 +1,9 @@
+TEST_NAME = insertTest
+TEST_SRC	= $(TEST_NAME).c
+SRC 			= $(wildcard ../../src/*.c)
+CFLAGS 	= -std=c11 -fsanitize=address -Wall -mtune=native -g
+EXE 		= $(TEST_NAME).out
+
+.PHONY: $(TEST_NAME)
+insertTest: $(SRC)
+	gcc $(TEST_SRC) $(SRC) -o $(EXE) $(CFLAGS)


### PR DESCRIPTION
these changes allow the FastaVector library to be compiled from a c++ context. This library uses the C 'restrict' keyword to improve performance, but c++ instead uses '__restrict__' as an implementation defined keyword. Now, it should play nice for either C or C++.