### PR TITLE
Remove sequence terminators

### DIFF
--- a/src/FastaVector.c
+++ b/src/FastaVector.c
@@ -272,12 +272,6 @@ fastaVectorAddSequenceToList(struct FastaVector *fastaVector, char *header,
       return FASTA_VECTOR_ALLOCATION_FAIL;
     }
   }
-  // add the null terminator to end the sequence
-  bool addSequenceCharResult =
-      fastaVectorAddCharToSequenceVector(fastaVector, '\0');
-  if (__builtin_expect(!addSequenceCharResult, false)) {
-    return FASTA_VECTOR_ALLOCATION_FAIL;
-  }
 
   return FASTA_VECTOR_OK;
 }

--- a/src/FastaVector.c
+++ b/src/FastaVector.c
@@ -80,16 +80,6 @@ fastaVectorReadFasta(const char *restrict const fileSrc,
       if (charFromFile == '>') {
         readState = FASTA_VECTOR_READ_HEADER;
 
-        // null terminate the previous sequence (if this isn't the first header)
-        if (fastaVector->metadata.count != 0) {
-          bool addCharResult =
-              fastaVectorAddCharToSequenceVector(fastaVector, '\0');
-          if (__builtin_expect(!addCharResult, false)) {
-            fclose(fastaFile);
-            return FASTA_VECTOR_ALLOCATION_FAIL;
-          }
-        }
-
         bool addHeaderResult = fastaVectorAddNewHeader(fastaVector);
         if (__builtin_expect(!addHeaderResult, false)) {
           fclose(fastaFile);
@@ -161,12 +151,6 @@ fastaVectorReadFasta(const char *restrict const fileSrc,
     }
   }
 
-  // null terminate this last sequence before we're done.
-  bool addCharResult = fastaVectorAddCharToSequenceVector(fastaVector, '\0');
-  if (__builtin_expect(!addCharResult, false)) {
-    fclose(fastaFile);
-    return FASTA_VECTOR_ALLOCATION_FAIL;
-  }
 
   fclose(fastaFile);
   return FASTA_VECTOR_OK;
@@ -231,19 +215,6 @@ fastaVectorWriteFasta(const char *restrict const fileSrc,
           (sequenceWritePosition + fileLineLength) < sequenceEndPosition
               ? fileLineLength
               : sequenceEndPosition - sequenceWritePosition;
-
-      size_t sequenceLineEndPosition = sequenceWritePosition + fileLineLength;
-      // if the sequence appears to be null terminated, don't write that last
-      // character (the null terminator)
-      if ((sequenceLineEndPosition == sequenceEndPosition)) {
-        bool sequenceIsNullTerminated =
-            fastaVector->sequence.charData[sequenceLineEndPosition - 1] == '\0';
-        // if the sequence is null terminated, decrease the line length by 1 to
-        // not write the null terminator.
-        if (sequenceIsNullTerminated) {
-          thisLineLength--;
-        }
-      }
 
       size_t bytesWritten =
           fwrite(fastaVector->sequence.charData + sequenceWritePosition,

--- a/src/FastaVector.c
+++ b/src/FastaVector.c
@@ -52,7 +52,7 @@ void fastaVectorDealloc(struct FastaVector *fastaVector) {
 }
 #ifdef __cplusplus
 enum FastaVectorReturnCode
-fastaVectorReadFasta(const char * __restrict__ const fileSrc,
+fastaVectorReadFasta(const char *__restrict__ const fileSrc,
                      struct FastaVector *fastaVector) {
 #else
 enum FastaVectorReturnCode
@@ -151,13 +151,12 @@ fastaVectorReadFasta(const char *restrict const fileSrc,
     }
   }
 
-
   fclose(fastaFile);
   return FASTA_VECTOR_OK;
 }
 
 #ifdef __cplusplus
-fastaVectorWriteFasta(const char * __restrict__ const fileSrc,
+fastaVectorWriteFasta(const char *__restrict__ const fileSrc,
                       struct FastaVector *fastaVector,
                       uint32_t fileLineLength) {
 #else

--- a/src/FastaVector.h
+++ b/src/FastaVector.h
@@ -100,7 +100,7 @@ void fastaVectorDealloc(struct FastaVector *fastaVector);
  */
 #ifdef __cplusplus
 enum FastaVectorReturnCode
-fastaVectorReadFasta(const char * __restrict__ const fileSrc,
+fastaVectorReadFasta(const char *__restrict__ const fileSrc,
                      struct FastaVector *fastaVector);
 #else
 enum FastaVectorReturnCode
@@ -126,7 +126,7 @@ fastaVectorReadFasta(const char *restrict const fileSrc,
  */
 #ifdef __cplusplus
 enum FastaVectorReturnCode
-fastaVectorWriteFasta(const char * __restrict__ const filePath,
+fastaVectorWriteFasta(const char *__restrict__ const filePath,
                       struct FastaVector *fastaVector, uint32_t fileLineLength);
 #else
 enum FastaVectorReturnCode

--- a/src/FastaVector.h
+++ b/src/FastaVector.h
@@ -182,10 +182,11 @@ void fastaVectorFastaGetHeader(struct FastaVector *fastaVector,
  * @param sequenceIndex the index of the sequence to be retrieved
  * (zero-indexed).
  * @param sequencePtr pointer to the char pointer that will be set to the start
- * of the sequence.
- * @param sequenceLength pointer to store the sequence length into.
+ * of the sequence. Ptr will be null if sequenceIndex was out of range.
+ * @param sequenceLength pointer to store the sequence length into, or 0 if
+ * if sequenceIndex was out of range.
  *
- * TODO: Should we return a statuc code in case the index was out of bounds?
+ * TODO: Should we return a static code in case the index was out of bounds?
  *
  */
 void fastaVectorFastaGetSequence(struct FastaVector *fastaVector,

--- a/tests/fileReadTest/fileReadTest.c
+++ b/tests/fileReadTest/fileReadTest.c
@@ -20,7 +20,7 @@ void readTest(char **const testHeaderStrings, char **const testSequenceStrings,
   for (size_t i = 0; i < numHeaders; i++) {
     // add 1 to the strings for the  null terminators
     const size_t expectedHeaderLength = strlen(testHeaderStrings[i]) + 1;
-    const size_t expectedSequenceLength = strlen(testSequenceStrings[i]) + 1;
+    const size_t expectedSequenceLength = strlen(testSequenceStrings[i]);
     size_t headerLength;
     char *headerPtr;
     fastaVectorFastaGetHeader(&fastaVector, i, &headerPtr, &headerLength);
@@ -58,12 +58,6 @@ void readTest(char **const testHeaderStrings, char **const testSequenceStrings,
             i, terminator);
     testAssertString(terminator == '\0', buffer);
 
-    terminator = sequencePtr[sequenceLength - 1];
-    sprintf(buffer,
-            "sequence index %zu was not null terminated! (found char %c after "
-            "the end of the header)",
-            i, terminator);
-    testAssertString(terminator == '\0', buffer);
   }
 
   fastaVectorDealloc(&fastaVector);

--- a/tests/fileWriteTest/fileWriteTest.c
+++ b/tests/fileWriteTest/fileWriteTest.c
@@ -78,19 +78,20 @@ void fastaVectorFileWriteTest(const size_t numSequences, const char *fileSrc) {
 
   char **headers = malloc(numSequences * sizeof(char *));
   char **sequences = malloc(numSequences * sizeof(char *));
+  uint64_t *sequenceLengths = malloc(numSequences * sizeof(uint64_t));
 
   // populate the fastaVector
   for (size_t sequenceNum = 0; sequenceNum < numSequences; sequenceNum++) {
     const size_t headerLength = rand() % 100 + 1;
     const size_t sequenceLength = (rand() % 100) + 1;
     headers[sequenceNum] = malloc((headerLength + 1) * sizeof(char));
-    sequences[sequenceNum] = malloc((sequenceLength + 1) * sizeof(char));
+    sequences[sequenceNum] = malloc((sequenceLength) * sizeof(char));
+    sequenceLengths[sequenceNum] = sequenceLength;
     generateRandomFastaString(headers[sequenceNum], headerLength);
     generateRandomFastaString(sequences[sequenceNum], sequenceLength);
 
-    // null terminate the header and sequence in the
+    // null terminate the header
     headers[sequenceNum][headerLength] = 0;
-    sequences[sequenceNum][sequenceLength] = 0;
 
     returnCode = fastaVectorAddSequenceToList(
         &fastaVector, headers[sequenceNum], headerLength,
@@ -103,7 +104,7 @@ void fastaVectorFileWriteTest(const size_t numSequences, const char *fileSrc) {
     const char *headerPtr = headers[sequenceNum];
     const char *sequencePtr = sequences[sequenceNum];
     const size_t headerLength = strlen(headers[sequenceNum]);
-    const size_t sequenceLength = strlen(sequences[sequenceNum]);
+    const size_t sequenceLength = sequenceLengths[sequenceNum];
 
     char *headerFromVector;
     char *sequenceFromVector;
@@ -122,9 +123,9 @@ void fastaVectorFileWriteTest(const size_t numSequences, const char *fileSrc) {
                      buffer);
     sprintf(buffer, "sequence was supposed to be length %zu, but got %zu.",
             sequenceLength, sequenceLengthFromVector);
-    testAssertString((sequenceLength + 1) == sequenceLengthFromVector, buffer);
-    sprintf(buffer, "sequence was supposed to match %s, but got %.*s.",
-            sequencePtr, (int)sequenceLengthFromVector, sequenceFromVector);
+    testAssertString((sequenceLength) == sequenceLengthFromVector, buffer);
+    sprintf(buffer, "sequence was supposed to match %.*s, but got %.*s.",
+            (int)sequenceLength, sequencePtr, (int)sequenceLengthFromVector, sequenceFromVector);
     testAssertString(
         strncmp(sequenceFromVector, sequencePtr, sequenceLength) == 0, buffer);
   }
@@ -250,6 +251,7 @@ void fastaVectorFileWriteTest(const size_t numSequences, const char *fileSrc) {
   }
   free(headers);
   free(sequences);
+  free(sequenceLengths);
   fastaVectorDealloc(&fastaVector);
   fastaVectorDealloc(&fastaReadVector);
 }

--- a/tests/insertTest/insertTest.c
+++ b/tests/insertTest/insertTest.c
@@ -129,7 +129,7 @@ void testInsertSequences() {
             "length %zu",
             i, sequenceLengths[i], sequenceStartPosition, sequenceEndPosition,
             sequenceLength);
-    testAssertString((sequenceLengths[i] + 1) == sequenceLength, buffer);
+    testAssertString(sequenceLengths[i] == sequenceLength, buffer);
 
     for (size_t i = 0; i < numSequences; i++) {
       size_t sequenceStartPosition =


### PR DESCRIPTION
this change removes the null terminators in between sequences inside the FastaVector data structure. This will make it easier to treat the overall sequence struct as a single concatenated sequence. Instead of using the null terminators to print the individual sequences, the fastaVectorFastaGetSequence() function gets the starting ptr to the sequence and the length, so printing with a printf("%s.*") should still be easy.