### PR TITLE
add checks on dealloc to not free NULL data

### DIFF
--- a/src/FastaVectorMetadataVector.c
+++ b/src/FastaVectorMetadataVector.c
@@ -43,6 +43,9 @@ bool fastaVectorMetadataVectorResize(struct FastaVectorMetadataVector *vector) {
 }
 
 void fastaVectorMetadataVectorDealloc(
-    struct FastaVectorMetadataVector *vector) {
-  free(vector->data);
+  struct FastaVectorMetadataVector *vector) {
+  if(vector->data != NULL){
+    free(vector->data);
+    vector->data = NULL;
+  }
 }

--- a/src/FastaVectorMetadataVector.c
+++ b/src/FastaVectorMetadataVector.c
@@ -43,8 +43,8 @@ bool fastaVectorMetadataVectorResize(struct FastaVectorMetadataVector *vector) {
 }
 
 void fastaVectorMetadataVectorDealloc(
-  struct FastaVectorMetadataVector *vector) {
-  if(vector->data != NULL){
+    struct FastaVectorMetadataVector *vector) {
+  if (vector->data != NULL) {
     free(vector->data);
     vector->data = NULL;
   }

--- a/src/FastaVectorString.c
+++ b/src/FastaVectorString.c
@@ -10,7 +10,7 @@ bool fastaVectorStringInit(struct FastaVectorString *vector) {
 }
 
 void fastaVectorStringDealloc(struct FastaVectorString *vector) {
-  if(vector->charData != NULL){
+  if (vector->charData != NULL) {
     free(vector->charData);
     vector->charData = NULL;
   }

--- a/src/FastaVectorString.c
+++ b/src/FastaVectorString.c
@@ -10,7 +10,10 @@ bool fastaVectorStringInit(struct FastaVectorString *vector) {
 }
 
 void fastaVectorStringDealloc(struct FastaVectorString *vector) {
-  free(vector->charData);
+  if(vector->charData != NULL){
+    free(vector->charData);
+    vector->charData = NULL;
+  }
 }
 
 bool fastaVectorStringAddChar(struct FastaVectorString *vector, const char c) {


### PR DESCRIPTION
This change allows the design to deallocate the sequence, or header as needed. this may reduce memory in an application using the library in certain situations.