### PR TITLE
add necessary header files to cmake install system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,10 @@ set_target_properties(
 
 install(TARGETS fastavector)
 
+install(FILES ${H_FILES}
+    DESTINATION include
+)
+
 # ----------
 # Unit Tests
 # ----------


### PR DESCRIPTION
this change fixes the cmake build system. When installing, the cmake build system was not correctly installing two of the three necessary headers. Now, these will all be installed when using the cmake build system. 

The legacy makefile should be unaffected.