### PR TITLE
fix issue where FastaVector.h was being installed twice.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,28 +27,38 @@ set(
 
 add_library(
         fastavector_static STATIC
-
         ${C_FILES}
 )
 
 add_library(
         fastavector SHARED
-
         ${C_FILES}
 )
 
+# Specify different sets of header files for shared and static libraries
 set_target_properties(
-        fastavector_static fastavector
-
+        fastavector
         PROPERTIES
-        PUBLIC_HEADER ${H_FILES}
+        PUBLIC_HEADER src/FastaVector.h
 )
 
-install(TARGETS fastavector)
+# set_target_properties(
+#         fastavector_static
+#         PROPERTIES
+#         PUBLIC_HEADER src/FastaVector.h
+# )
 
-install(FILES ${H_FILES}
+install(TARGETS fastavector fastavector_static)
+
+# Install only the necessary header files for each library
+install(FILES src/FastaVectorMetadataVector.h
     DESTINATION include
 )
+
+install(FILES src/FastaVectorString.h
+    DESTINATION include
+)
+
 
 # ----------
 # Unit Tests

--- a/tests/fileReadTest/fileReadTest.c
+++ b/tests/fileReadTest/fileReadTest.c
@@ -57,7 +57,6 @@ void readTest(char **const testHeaderStrings, char **const testSequenceStrings,
             "the end of the header)",
             i, terminator);
     testAssertString(terminator == '\0', buffer);
-
   }
 
   fastaVectorDealloc(&fastaVector);

--- a/tests/fileWriteTest/fileWriteTest.c
+++ b/tests/fileWriteTest/fileWriteTest.c
@@ -125,7 +125,8 @@ void fastaVectorFileWriteTest(const size_t numSequences, const char *fileSrc) {
             sequenceLength, sequenceLengthFromVector);
     testAssertString((sequenceLength) == sequenceLengthFromVector, buffer);
     sprintf(buffer, "sequence was supposed to match %.*s, but got %.*s.",
-            (int)sequenceLength, sequencePtr, (int)sequenceLengthFromVector, sequenceFromVector);
+            (int)sequenceLength, sequencePtr, (int)sequenceLengthFromVector,
+            sequenceFromVector);
     testAssertString(
         strncmp(sequenceFromVector, sequencePtr, sequenceLength) == 0, buffer);
   }


### PR DESCRIPTION
This really only fixes a small warning when uninstalling the library through the install_manifest.txt