### PR TITLE
Binary search local position

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,4 +157,34 @@ if (BUILD_TESTING)
                 PROPERTIES
                 WORKING_DIRECTORY tests/insertTest
         )
+
+        # multiSequenceTest
+
+        add_executable(
+                multiSequenceTest
+
+                tests/multiSequenceTest/multiSequenceTest.c
+                ${C_FILES}
+        )
+        target_compile_options(
+                multiSequenceTest
+
+                PRIVATE
+                -mtune=native
+                -Wall
+                -Wextra
+                -g
+        )
+        target_link_options(
+                multiSequenceTest
+
+                PRIVATE
+        )
+        add_test(NAME multiSequenceTest COMMAND multiSequenceTest)
+        set_tests_properties(
+                multiSequenceTest
+
+                PROPERTIES
+                WORKING_DIRECTORY tests/multiSequenceTest
+        )
 endif ()

--- a/src/FastaVector.c
+++ b/src/FastaVector.c
@@ -350,7 +350,7 @@ bool fastaVectorGetLocalSequencePositionFromGlobal(
     const struct FastaVector *const fastaVector,
     const size_t globalSequencePosition,
     struct FastaVectorLocalPosition *localPosition) {
-  if (localPosition == NULL) {
+  if (__builtin_expect(localPosition == NULL, 0)) {
     return false;
   }
   // check to see if this is outside the bounds

--- a/src/FastaVector.c
+++ b/src/FastaVector.c
@@ -353,25 +353,40 @@ bool fastaVectorGetLocalSequencePositionFromGlobal(
   if (localPosition == NULL) {
     return false;
   }
-  for (size_t sequenceIndex = 0; sequenceIndex < fastaVector->metadata.count;
-       sequenceIndex++) {
-    const size_t sequenceStartPosition =
-        sequenceIndex == 0
-            ? 0
-            : fastaVector->metadata.data[sequenceIndex - 1].sequenceEndPosition;
-    const size_t sequenceEndPosition =
-        fastaVector->metadata.data[sequenceIndex].sequenceEndPosition;
+  // check to see if this is outside the bounds
+  if (__builtin_expect(
+          globalSequencePosition >
+              fastaVector->metadata.data[fastaVector->metadata.count - 1]
+                  .sequenceEndPosition,
+          0)) {
+    return false;
+  }
 
-    if (globalSequencePosition <= sequenceEndPosition) {
-      const size_t positionInSequence =
-          globalSequencePosition - sequenceStartPosition;
-      localPosition->sequenceIndex = sequenceIndex;
-      localPosition->positionInSequence = positionInSequence;
-      return true;
+  // perform binary search
+  const int64_t numSequences = fastaVector->metadata.count;
+  int64_t lowerBound = 0;
+  int64_t upperBound = numSequences - 1;
+  while (lowerBound <= upperBound) {
+    const int64_t midpoint = (upperBound + lowerBound) / 2;
+    const size_t midpointEndPosition =
+        fastaVector->metadata.data[midpoint].sequenceEndPosition;
+
+    if (globalSequencePosition < midpointEndPosition) {
+      upperBound = midpoint - 1;
+    } else {
+      lowerBound = midpoint + 1;
     }
   }
 
+  localPosition->sequenceIndex = upperBound + 1;
+  localPosition->positionInSequence =
+      localPosition->sequenceIndex == 0
+          ? globalSequencePosition
+          : globalSequencePosition -
+                fastaVector->metadata.data[localPosition->sequenceIndex - 1]
+                    .sequenceEndPosition;
+
   // if no sequence is found that contains the given position, return false to
   // show failure
-  return false;
+  return true;
 }

--- a/tests/multiSequenceTest/makefile
+++ b/tests/multiSequenceTest/makefile
@@ -1,7 +1,7 @@
 TEST_NAME = multiSequenceTest
 TEST_SRC	= $(TEST_NAME).c
 SRC 			= $(wildcard ../../src/*.c)
-CFLAGS 	= -std=c11 -Wall -mtune=native -g
+CFLAGS 	= -std=c11 -Wall -mtune=native -g -O0
 EXE 		= $(TEST_NAME).out
 
 .PHONY: $(TEST_NAME)

--- a/tests/multiSequenceTest/multiSequenceTest.c
+++ b/tests/multiSequenceTest/multiSequenceTest.c
@@ -35,84 +35,118 @@ int main() {
     testAssertString(strcmp(seqs[i], charPtr) == 0,
                      "headers did not match exactly.");
   }
-  
+
   // test getting the local positions
   struct FastaVectorLocalPosition lp;
   bool locateResult =
       fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 0, &lp);
   testAssertString(locateResult, "locate result returned false");
-  testAssertString(lp.positionInSequence == 0, "locate result position did not recieve expected value");
-  testAssertString(lp.sequenceIndex == 0, "locate result sequence Index did not recieve expected value");
+  testAssertString(lp.positionInSequence == 0,
+                   "locate result position did not recieve expected value");
+  testAssertString(
+      lp.sequenceIndex == 0,
+      "locate result sequence Index did not recieve expected value");
 
   locateResult =
       fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 3, &lp);
   testAssertString(locateResult, "locate result returned false");
-  testAssertString(lp.positionInSequence == 3, "locate result position did not recieve expected value");
-  testAssertString(lp.sequenceIndex == 0, "locate result sequence Index did not recieve expected value");
+  testAssertString(lp.positionInSequence == 3,
+                   "locate result position did not recieve expected value");
+  testAssertString(
+      lp.sequenceIndex == 0,
+      "locate result sequence Index did not recieve expected value");
 
-  //skipping the null seperator
+  // skipping the null seperator
   locateResult =
       fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 5, &lp);
   testAssertString(locateResult, "locate result returned false");
-  testAssertString(lp.positionInSequence == 0, "locate result position did not recieve expected value");
-  testAssertString(lp.sequenceIndex == 1, "locate result sequence Index did not recieve expected value");
+  testAssertString(lp.positionInSequence == 0,
+                   "locate result position did not recieve expected value");
+  testAssertString(
+      lp.sequenceIndex == 1,
+      "locate result sequence Index did not recieve expected value");
 
   locateResult =
       fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 8, &lp);
   testAssertString(locateResult, "locate result returned false");
-  testAssertString(lp.positionInSequence == 3, "locate result position did not recieve expected value");
-  testAssertString(lp.sequenceIndex == 1, "locate result sequence Index did not recieve expected value");
+  testAssertString(lp.positionInSequence == 3,
+                   "locate result position did not recieve expected value");
+  testAssertString(
+      lp.sequenceIndex == 1,
+      "locate result sequence Index did not recieve expected value");
 
-  //skipping the null seperator
+  // skipping the null seperator
   locateResult =
       fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 10, &lp);
   testAssertString(locateResult, "locate result returned false");
-  testAssertString(lp.positionInSequence == 0, "locate result position did not recieve expected value");
-  testAssertString(lp.sequenceIndex == 2, "locate result sequence Index did not recieve expected value");
+  testAssertString(lp.positionInSequence == 0,
+                   "locate result position did not recieve expected value");
+  testAssertString(
+      lp.sequenceIndex == 2,
+      "locate result sequence Index did not recieve expected value");
 
   locateResult =
       fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 12, &lp);
   testAssertString(locateResult, "locate result returned false");
-  testAssertString(lp.positionInSequence == 2, "locate result position did not recieve expected value");
-  testAssertString(lp.sequenceIndex == 2, "locate result sequence Index did not recieve expected value");
+  testAssertString(lp.positionInSequence == 2,
+                   "locate result position did not recieve expected value");
+  testAssertString(
+      lp.sequenceIndex == 2,
+      "locate result sequence Index did not recieve expected value");
 
-  //skipping the null seperator
+  // skipping the null seperator
   locateResult =
       fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 14, &lp);
   testAssertString(locateResult, "locate result returned false");
-  testAssertString(lp.positionInSequence == 0, "locate result position did not recieve expected value");
-  testAssertString(lp.sequenceIndex == 3, "locate result sequence Index did not recieve expected value");
+  testAssertString(lp.positionInSequence == 0,
+                   "locate result position did not recieve expected value");
+  testAssertString(
+      lp.sequenceIndex == 3,
+      "locate result sequence Index did not recieve expected value");
 
-  //skipping the null seperator
+  // skipping the null seperator
   locateResult =
       fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 16, &lp);
   testAssertString(locateResult, "locate result returned false");
-  testAssertString(lp.positionInSequence == 0, "locate result position did not recieve expected value");
-  testAssertString(lp.sequenceIndex == 4, "locate result sequence Index did not recieve expected value");
+  testAssertString(lp.positionInSequence == 0,
+                   "locate result position did not recieve expected value");
+  testAssertString(
+      lp.sequenceIndex == 4,
+      "locate result sequence Index did not recieve expected value");
 
   locateResult =
       fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 19, &lp);
   testAssertString(locateResult, "locate result returned false");
-  testAssertString(lp.positionInSequence == 3, "locate result position did not recieve expected value");
-  testAssertString(lp.sequenceIndex == 4, "locate result sequence Index did not recieve expected value");
+  testAssertString(lp.positionInSequence == 3,
+                   "locate result position did not recieve expected value");
+  testAssertString(
+      lp.sequenceIndex == 4,
+      "locate result sequence Index did not recieve expected value");
 
-  //skipping the null seperator
+  // skipping the null seperator
   locateResult =
       fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 21, &lp);
   testAssertString(locateResult, "locate result returned false");
-  testAssertString(lp.positionInSequence == 0, "locate result position did not recieve expected value");
-  testAssertString(lp.sequenceIndex == 5, "locate result sequence Index did not recieve expected value");
+  testAssertString(lp.positionInSequence == 0,
+                   "locate result position did not recieve expected value");
+  testAssertString(
+      lp.sequenceIndex == 5,
+      "locate result sequence Index did not recieve expected value");
 
   locateResult =
       fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 23, &lp);
   testAssertString(locateResult, "locate result returned false");
-  testAssertString(lp.positionInSequence == 2, "locate result position did not recieve expected value");
-  testAssertString(lp.sequenceIndex == 5, "locate result sequence Index did not recieve expected value");
+  testAssertString(lp.positionInSequence == 2,
+                   "locate result position did not recieve expected value");
+  testAssertString(
+      lp.sequenceIndex == 5,
+      "locate result sequence Index did not recieve expected value");
 
   locateResult =
       fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 26, &lp);
-  testAssertString(!locateResult, "locate result after sequence end did not return false, but should have");
+  testAssertString(
+      !locateResult,
+      "locate result after sequence end did not return false, but should have");
 
-
-      printf("test finished\n");
+  printf("test finished\n");
 }

--- a/tests/multiSequenceTest/multiSequenceTest.c
+++ b/tests/multiSequenceTest/multiSequenceTest.c
@@ -35,6 +35,84 @@ int main() {
     testAssertString(strcmp(seqs[i], charPtr) == 0,
                      "headers did not match exactly.");
   }
+  
+  // test getting the local positions
+  struct FastaVectorLocalPosition lp;
+  bool locateResult =
+      fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 0, &lp);
+  testAssertString(locateResult, "locate result returned false");
+  testAssertString(lp.positionInSequence == 0, "locate result position did not recieve expected value");
+  testAssertString(lp.sequenceIndex == 0, "locate result sequence Index did not recieve expected value");
 
-  printf("test finished\n");
+  locateResult =
+      fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 3, &lp);
+  testAssertString(locateResult, "locate result returned false");
+  testAssertString(lp.positionInSequence == 3, "locate result position did not recieve expected value");
+  testAssertString(lp.sequenceIndex == 0, "locate result sequence Index did not recieve expected value");
+
+  //skipping the null seperator
+  locateResult =
+      fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 5, &lp);
+  testAssertString(locateResult, "locate result returned false");
+  testAssertString(lp.positionInSequence == 0, "locate result position did not recieve expected value");
+  testAssertString(lp.sequenceIndex == 1, "locate result sequence Index did not recieve expected value");
+
+  locateResult =
+      fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 8, &lp);
+  testAssertString(locateResult, "locate result returned false");
+  testAssertString(lp.positionInSequence == 3, "locate result position did not recieve expected value");
+  testAssertString(lp.sequenceIndex == 1, "locate result sequence Index did not recieve expected value");
+
+  //skipping the null seperator
+  locateResult =
+      fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 10, &lp);
+  testAssertString(locateResult, "locate result returned false");
+  testAssertString(lp.positionInSequence == 0, "locate result position did not recieve expected value");
+  testAssertString(lp.sequenceIndex == 2, "locate result sequence Index did not recieve expected value");
+
+  locateResult =
+      fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 12, &lp);
+  testAssertString(locateResult, "locate result returned false");
+  testAssertString(lp.positionInSequence == 2, "locate result position did not recieve expected value");
+  testAssertString(lp.sequenceIndex == 2, "locate result sequence Index did not recieve expected value");
+
+  //skipping the null seperator
+  locateResult =
+      fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 14, &lp);
+  testAssertString(locateResult, "locate result returned false");
+  testAssertString(lp.positionInSequence == 0, "locate result position did not recieve expected value");
+  testAssertString(lp.sequenceIndex == 3, "locate result sequence Index did not recieve expected value");
+
+  //skipping the null seperator
+  locateResult =
+      fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 16, &lp);
+  testAssertString(locateResult, "locate result returned false");
+  testAssertString(lp.positionInSequence == 0, "locate result position did not recieve expected value");
+  testAssertString(lp.sequenceIndex == 4, "locate result sequence Index did not recieve expected value");
+
+  locateResult =
+      fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 19, &lp);
+  testAssertString(locateResult, "locate result returned false");
+  testAssertString(lp.positionInSequence == 3, "locate result position did not recieve expected value");
+  testAssertString(lp.sequenceIndex == 4, "locate result sequence Index did not recieve expected value");
+
+  //skipping the null seperator
+  locateResult =
+      fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 21, &lp);
+  testAssertString(locateResult, "locate result returned false");
+  testAssertString(lp.positionInSequence == 0, "locate result position did not recieve expected value");
+  testAssertString(lp.sequenceIndex == 5, "locate result sequence Index did not recieve expected value");
+
+  locateResult =
+      fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 23, &lp);
+  testAssertString(locateResult, "locate result returned false");
+  testAssertString(lp.positionInSequence == 2, "locate result position did not recieve expected value");
+  testAssertString(lp.sequenceIndex == 5, "locate result sequence Index did not recieve expected value");
+
+  locateResult =
+      fastaVectorGetLocalSequencePositionFromGlobal(&fastaVector, 26, &lp);
+  testAssertString(!locateResult, "locate result after sequence end did not return false, but should have");
+
+
+      printf("test finished\n");
 }


### PR DESCRIPTION
This PR improves the process of finding the local sequence position and sequence index by using binary search. When fastas contain many sequences, linearly searching through them can take quite a while. This should improve runtimes in these cases.