### PR TITLE
Better restrict

### DIFF
--- a/src/FastaVector.c
+++ b/src/FastaVector.c
@@ -55,7 +55,6 @@ enum FastaVectorReturnCode
 fastaVectorReadFasta(const char *_RESTRICT_ const fileSrc,
                      struct FastaVector *fastaVector) {
 
-
   FILE *fastaFile = fopen(fileSrc, "r");
   if (__builtin_expect(!fastaFile, false)) {
     return FASTA_VECTOR_FILE_OPEN_FAIL;
@@ -267,9 +266,8 @@ fastaVectorAddSequenceToList(struct FastaVector *fastaVector, char *header,
 
 // return NULL for headerPtr and 0 for header length if the fastaVector does not
 // have a header for the given headerIndex
-void fastaVectorGetHeader(struct FastaVector *fastaVector,
-                               size_t headerIndex, char **headerPtr,
-                               size_t *headerLength) {
+void fastaVectorGetHeader(struct FastaVector *fastaVector, size_t headerIndex,
+                          char **headerPtr, size_t *headerLength) {
   if (__builtin_expect(headerIndex >= fastaVector->metadata.count, false)) {
     *headerLength = 0;
     *headerPtr = NULL;
@@ -289,8 +287,8 @@ void fastaVectorGetHeader(struct FastaVector *fastaVector,
 // return NULL for headerPtr and 0 for header length if the fastaVector does not
 // have a header for the given headerIndex
 void fastaVectorGetSequence(struct FastaVector *fastaVector,
-                                 size_t sequenceIndex, char **sequencePtr,
-                                 size_t *sequenceLength) {
+                            size_t sequenceIndex, char **sequencePtr,
+                            size_t *sequenceLength) {
   if (__builtin_expect(sequenceIndex >= fastaVector->metadata.count, false)) {
     *sequenceLength = 0;
     *sequencePtr = NULL;

--- a/src/FastaVector.c
+++ b/src/FastaVector.c
@@ -267,7 +267,7 @@ fastaVectorAddSequenceToList(struct FastaVector *fastaVector, char *header,
 
 // return NULL for headerPtr and 0 for header length if the fastaVector does not
 // have a header for the given headerIndex
-void fastaVectorFastaGetHeader(struct FastaVector *fastaVector,
+void fastaVectorGetHeader(struct FastaVector *fastaVector,
                                size_t headerIndex, char **headerPtr,
                                size_t *headerLength) {
   if (__builtin_expect(headerIndex >= fastaVector->metadata.count, false)) {
@@ -288,7 +288,7 @@ void fastaVectorFastaGetHeader(struct FastaVector *fastaVector,
 
 // return NULL for headerPtr and 0 for header length if the fastaVector does not
 // have a header for the given headerIndex
-void fastaVectorFastaGetSequence(struct FastaVector *fastaVector,
+void fastaVectorGetSequence(struct FastaVector *fastaVector,
                                  size_t sequenceIndex, char **sequencePtr,
                                  size_t *sequenceLength) {
   if (__builtin_expect(sequenceIndex >= fastaVector->metadata.count, false)) {

--- a/src/FastaVector.c
+++ b/src/FastaVector.c
@@ -50,15 +50,11 @@ void fastaVectorDealloc(struct FastaVector *fastaVector) {
   fastaVectorStringDealloc(&fastaVector->header);
   fastaVectorMetadataVectorDealloc(&fastaVector->metadata);
 }
-#ifdef __cplusplus
+
 enum FastaVectorReturnCode
-fastaVectorReadFasta(const char *__restrict__ const fileSrc,
+fastaVectorReadFasta(const char *_RESTRICT_ const fileSrc,
                      struct FastaVector *fastaVector) {
-#else
-enum FastaVectorReturnCode
-fastaVectorReadFasta(const char *restrict const fileSrc,
-                     struct FastaVector *fastaVector) {
-#endif
+
 
   FILE *fastaFile = fopen(fileSrc, "r");
   if (__builtin_expect(!fastaFile, false)) {
@@ -155,16 +151,10 @@ fastaVectorReadFasta(const char *restrict const fileSrc,
   return FASTA_VECTOR_OK;
 }
 
-#ifdef __cplusplus
-fastaVectorWriteFasta(const char *__restrict__ const fileSrc,
-                      struct FastaVector *fastaVector,
-                      uint32_t fileLineLength) {
-#else
 enum FastaVectorReturnCode
-fastaVectorWriteFasta(const char *restrict const fileSrc,
+fastaVectorWriteFasta(const char *_RESTRICT_ const fileSrc,
                       struct FastaVector *fastaVector,
                       uint32_t fileLineLength) {
-#endif
   FILE *fastaFile = fopen(fileSrc, "w+");
   if (!fastaFile) {
     return FASTA_VECTOR_FILE_WRITE_FAIL;

--- a/src/FastaVector.h
+++ b/src/FastaVector.h
@@ -13,6 +13,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+#define _RESTRICT_ __restrict__
+#else
+#define _RESTRICT_ restrict
+#endif
+
 /// @brief Primary struct that stores data for a given FASTA file.
 struct FastaVector {
   /// @brief Storage for the fasta sequence data.
@@ -98,15 +104,9 @@ void fastaVectorDealloc(struct FastaVector *fastaVector);
  * takes any properly formed fasta file, and loads all headers and sequences.
  *
  */
-#ifdef __cplusplus
 enum FastaVectorReturnCode
-fastaVectorReadFasta(const char *__restrict__ const fileSrc,
+fastaVectorReadFasta(const char *_RESTRICT_ const fileSrc,
                      struct FastaVector *fastaVector);
-#else
-enum FastaVectorReturnCode
-fastaVectorReadFasta(const char *restrict const fileSrc,
-                     struct FastaVector *fastaVector);
-#endif
 
 /**
  * @relates FastaVector
@@ -124,15 +124,9 @@ fastaVectorReadFasta(const char *restrict const fileSrc,
  * This function will overwrite the file at the given path.
  *
  */
-#ifdef __cplusplus
 enum FastaVectorReturnCode
-fastaVectorWriteFasta(const char *__restrict__ const filePath,
+fastaVectorWriteFasta(const char *_RESTRICT_ const filePath,
                       struct FastaVector *fastaVector, uint32_t fileLineLength);
-#else
-enum FastaVectorReturnCode
-fastaVectorWriteFasta(const char *restrict const filePath,
-                      struct FastaVector *fastaVector, uint32_t fileLineLength);
-#endif
 
 /**
  * @relates FastaVector
@@ -170,9 +164,8 @@ fastaVectorAddSequenceToList(struct FastaVector *fastaVector, char *header,
  * TODO: Should we return a statuc code in case the index was out of bounds?
  *
  */
-void fastaVectorFastaGetHeader(struct FastaVector *fastaVector,
-                               size_t headerIndex, char **headerPtr,
-                               size_t *headerLength);
+void fastaVectorGetHeader(struct FastaVector *fastaVector, size_t headerIndex,
+                          char **headerPtr, size_t *headerLength);
 
 /**
  * @relates FastaVector
@@ -189,9 +182,9 @@ void fastaVectorFastaGetHeader(struct FastaVector *fastaVector,
  * TODO: Should we return a static code in case the index was out of bounds?
  *
  */
-void fastaVectorFastaGetSequence(struct FastaVector *fastaVector,
-                                 size_t sequenceIndex, char **sequencePtr,
-                                 size_t *sequenceLength);
+void fastaVectorGetSequence(struct FastaVector *fastaVector,
+                            size_t sequenceIndex, char **sequencePtr,
+                            size_t *sequenceLength);
 
 /**
  * @relates FastaVector

--- a/tests/fileReadTest/fileReadTest.c
+++ b/tests/fileReadTest/fileReadTest.c
@@ -23,7 +23,7 @@ void readTest(char **const testHeaderStrings, char **const testSequenceStrings,
     const size_t expectedSequenceLength = strlen(testSequenceStrings[i]);
     size_t headerLength;
     char *headerPtr;
-    fastaVectorFastaGetHeader(&fastaVector, i, &headerPtr, &headerLength);
+    fastaVectorGetHeader(&fastaVector, i, &headerPtr, &headerLength);
     sprintf(buffer, "header length of %zu did not match expected length %zu.",
             headerLength, expectedHeaderLength);
 
@@ -38,7 +38,7 @@ void readTest(char **const testHeaderStrings, char **const testSequenceStrings,
 
     char *sequencePtr;
     size_t sequenceLength;
-    fastaVectorFastaGetSequence(&fastaVector, i, &sequencePtr, &sequenceLength);
+    fastaVectorGetSequence(&fastaVector, i, &sequencePtr, &sequenceLength);
     sprintf(buffer, "sequence length of %zu did not match expected length %zu.",
             sequenceLength, expectedSequenceLength);
     testAssertString(sequenceLength == expectedSequenceLength, buffer);
@@ -53,7 +53,7 @@ void readTest(char **const testHeaderStrings, char **const testSequenceStrings,
 
     char terminator = headerPtr[headerLength - 1];
     sprintf(buffer,
-            "header index %zu was not null terminated! (found char %c after "
+            "header index %zu was not null terminated! (found char %u after "
             "the end of the header)",
             i, terminator);
     testAssertString(terminator == '\0', buffer);

--- a/tests/fileWriteTest/fileWriteTest.c
+++ b/tests/fileWriteTest/fileWriteTest.c
@@ -110,9 +110,9 @@ void fastaVectorFileWriteTest(const size_t numSequences, const char *fileSrc) {
     char *sequenceFromVector;
     size_t headerLengthFromVector;
     size_t sequenceLengthFromVector;
-    fastaVectorFastaGetHeader(&fastaVector, sequenceNum, &headerFromVector,
+    fastaVectorGetHeader(&fastaVector, sequenceNum, &headerFromVector,
                               &headerLengthFromVector);
-    fastaVectorFastaGetSequence(&fastaVector, sequenceNum, &sequenceFromVector,
+    fastaVectorGetSequence(&fastaVector, sequenceNum, &sequenceFromVector,
                                 &sequenceLengthFromVector);
     sprintf(buffer, "header was supposed to be length %zu, but got %zu.",
             headerLength, headerLengthFromVector);
@@ -154,7 +154,7 @@ void fastaVectorFileWriteTest(const size_t numSequences, const char *fileSrc) {
   if (fastaVector.header.count != fastaReadVector.header.count) {
     size_t lastHeaderLen;
     char *lastHeaderPtr;
-    fastaVectorFastaGetHeader(&fastaVector, fastaVector.metadata.count - 1,
+    fastaVectorGetHeader(&fastaVector, fastaVector.metadata.count - 1,
                               &lastHeaderPtr, &lastHeaderLen);
     printf("headers did not match, \n h1: %.*s\n h2: %.*s\n hr: %.*s\n",
            (int)fastaVector.header.count, fastaVector.header.charData,


### PR DESCRIPTION
this pr changes the restrict keyword usage to allow for IDEs to better parse code. additionally, the functions for getting the individual sequences and headers was renamed to be less redundant.